### PR TITLE
fix missing symbol feedback_is_supported_pattern for ubuntu

### DIFF
--- a/src/dummy-feedback.c
+++ b/src/dummy-feedback.c
@@ -24,3 +24,7 @@ int feedback_deinitialize()
   return 0;
 }
 
+int feedback_is_supported_pattern()
+{
+  return 0;
+}


### PR DESCRIPTION
To prevent crash by missing symbol feedback_is_supported_pattern on
ubuntu backend, feedback_is_supported_pattern is added in dummy.