### PR TITLE
Append line feed end of dlog print

### DIFF
--- a/src/dlog.c
+++ b/src/dlog.c
@@ -24,18 +24,25 @@
 #include "asprintf.h"
 #endif
 
-int dlog_print( log_priority prio, const char *tag, const char *fmt, ... )
+int dlog_print_internal( log_priority prio, const char *tag, const char *fmt, va_list arg )
 {
-  va_list arg;
-  va_start(arg, fmt);
   int numChars = 0;
-
   char *format = NULL;
-  if( asprintf(&format, "%s:\e[21m %s: %s\e[0m", prio==DLOG_INFO?"\e[1;34mINFO":prio==DLOG_WARN?"\e[1;33mWARN":prio==DLOG_ERROR?"\e[1;91mERROR":"", tag, fmt))
+  if( asprintf(&format, "%s:\e[21m %s: %s\e[0m", prio==DLOG_DEBUG?"\e[1;37mDEBUG":prio==DLOG_INFO?"\e[1;34mINFO":prio==DLOG_WARN?"\e[1;33mWARN":prio==DLOG_ERROR?"\e[1;91mERROR":"", tag, fmt))
   {
     numChars = vfprintf(stderr, format, arg);
     free(format);
   }
+  return numChars;
+}
+
+int dlog_print( log_priority prio, const char *tag, const char *fmt, ... )
+{
+  va_list arg;
+  va_start(arg, fmt);
+
+  int numChars = dlog_print_internal(prio, tag, fmt, arg);
+
   va_end(arg);
   return numChars;
 }
@@ -44,14 +51,9 @@ int dlog_print_dotnet( log_priority prio, const char *tag, const char *fmt, ... 
 {
   va_list arg;
   va_start(arg, fmt);
-  int numChars = 0;
 
-  char *format = NULL;
-  if( asprintf(&format, "%s:\e[21m %s: %s\e[0m", prio==DLOG_INFO?"\e[1;34mINFO":prio==DLOG_WARN?"\e[1;33mWARN":prio==DLOG_ERROR?"\e[1;91mERROR":"", tag, fmt))
-  {
-    numChars = vfprintf(stderr, format, arg);
-    free(format);
-  }
+  int numChars = dlog_print_internal(prio, tag, fmt, arg);
+
   va_end(arg);
   return numChars;
 }

--- a/src/dlog.c
+++ b/src/dlog.c
@@ -27,11 +27,19 @@
 int dlog_print_internal( log_priority prio, const char *tag, const char *fmt, va_list arg )
 {
   int numChars = 0;
-  char *format = NULL;
-  if( asprintf(&format, "%s:\e[21m %s: %s\e[0m", prio==DLOG_DEBUG?"\e[1;37mDEBUG":prio==DLOG_INFO?"\e[1;34mINFO":prio==DLOG_WARN?"\e[1;33mWARN":prio==DLOG_ERROR?"\e[1;91mERROR":"", tag, fmt))
+  char *message = NULL;
+  int messageLength = vasprintf(&message, fmt, arg);
+  if(messageLength > 0)
   {
-    numChars = vfprintf(stderr, format, arg);
-    free(format);
+    // Append line feed if message is not end with line feed.
+    char lineFeed[2] = {'\0', '\0'};
+    if(message[messageLength-1] != '\n')
+    {
+      lineFeed[0] = '\n';
+    }
+
+    numChars = fprintf(stderr, "%s:\e[21m %s: %s%s\e[0m", prio==DLOG_DEBUG?"\e[1;37mDEBUG":prio==DLOG_INFO?"\e[1;34mINFO":prio==DLOG_WARN?"\e[1;33mWARN":prio==DLOG_ERROR?"\e[1;91mERROR":"", tag, message, lineFeed);
+    free(message);
   }
   return numChars;
 }


### PR DESCRIPTION
Append line feed end of dlog print.
Now we can print log line by line even if we don't append line feed end of messages.